### PR TITLE
Set redis-exporter name for port in service

### DIFF
--- a/stable/prometheus-redis-exporter/Chart.yaml
+++ b/stable/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.16.0
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 0.2.0
+version: 0.2.1
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/stable/prometheus-redis-exporter/templates/service.yaml
+++ b/stable/prometheus-redis-exporter/templates/service.yaml
@@ -12,7 +12,8 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: redis-exporter
+      port: {{ .Values.service.port }}
       targetPort: exporter-port
       protocol: TCP
   selector:


### PR DESCRIPTION
<!--
Thank you for contributing to kubernetes/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/kubernetes/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

Named port for service helps in configuring Prometheus' ServiceMonitor
